### PR TITLE
Target Windows XP toolset

### DIFF
--- a/QMPCoverArtVis/QMPCoverArtVis/QCDVisualsDLL.cpp
+++ b/QMPCoverArtVis/QMPCoverArtVis/QCDVisualsDLL.cpp
@@ -525,7 +525,7 @@ BOOL CALLBACK AboutProc(HWND dlg, UINT msg, WPARAM wParam, LPARAM lParam)
 //==Property Sheet Initialization Function==
 void PropertySheetInit(HWND parentWindow, HINSTANCE pluginInst)
 {
-	const NUM_PAGES = 7;
+	const int NUM_PAGES = 7;
     PROPSHEETPAGE psp[NUM_PAGES];
     PROPSHEETHEADER psh;
 

--- a/QMPCoverArtVis/QMPCoverArtVis/QMPCoverArtVis.vcxproj
+++ b/QMPCoverArtVis/QMPCoverArtVis/QMPCoverArtVis.vcxproj
@@ -22,32 +22,32 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{C048D4ED-D661-46B0-9620-FB03315E43D3}</ProjectGuid>
     <RootNamespace>QMPCoverArtVis</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -75,10 +75,11 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
+      <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>gdiplus.lib;wininet.lib;Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -86,10 +87,11 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
+      <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
+      <AdditionalDependencies>gdiplus.lib;wininet.lib;Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -99,12 +101,13 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
+      <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>gdiplus.lib;wininet.lib;Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -114,12 +117,13 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <ConformanceMode>true</ConformanceMode>
+      <ConformanceMode>false</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>gdiplus.lib;wininet.lib;Comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,18 @@
 # QMPCoverArtVis
-Visualization plug-in for the defunct Quintessential Media Player. It was written for Windows XP with the last release (version 2.971) on October 21st, 2004. Compilers have become better and more stringent, so this project does not compile in its current state.
+Visualization plug-in for the defunct Quintessential Media Player. It was written for Windows XP with the last release (version 2.971) on October 21st, 2004.
 
-# Original Description
+## Compilation and Linking
+Compilers have become better and more stringent, so this project does not compile in its current state when targeting modern Windows. The solution has been set up to target the Windows XP Platform Toolset (Visual Studio 2017 - Windows XP (v141_xp)) using Visual Studio 2019. MFC support is also required (for resources).
+
+In addition, conformance mode (/permissive-) was turned off to allow the Windows XP API to compile. These dependencies are linked: gdiplus.lib, wininet.lib, Comctl32.lib
+
+See https://web.archive.org/web/20210315184252/https://docs.microsoft.com/en-us/cpp/build/configuring-programs-for-windows-xp?view=msvc-160 for information on targeting Windows XP.
+
+This support for Windows XP is deprecated, so it may not be possible to compile in the future without many changes.
+
+## Original Description
 https://web.archive.org/web/20160307221351/http://quinnware.com/list_plugins.php?plugin=19
+
 ![QMPCoverArtVis example](https://web.archive.org/web/20150428075727im_/http://www.quinnware.com/img/plugin_screens/CoverArtVis.jpg)
 
 This plugin allows one to load cover art image files to the vis window (created with cover art in mind but any picture file will work)!

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In addition, conformance mode (/permissive-) was turned off to allow the Windows
 
 See https://web.archive.org/web/20210315184252/https://docs.microsoft.com/en-us/cpp/build/configuring-programs-for-windows-xp?view=msvc-160 for information on targeting Windows XP.
 
-This support for Windows XP is deprecated, so it may not be possible to compile in the future without many changes.
+Visual Studio's support for Windows XP is deprecated, so it may not be possible to compile in the future without many changes.
 
 ## Original Description
 https://web.archive.org/web/20160307221351/http://quinnware.com/list_plugins.php?plugin=19


### PR DESCRIPTION
- Target the Windows XP toolset: v141_xp
- Turn off conformance mode (/permissive-)
- Add library dependencies: gdiplus.lib, wininet.lib, Comctl32.lib